### PR TITLE
Change commands to trigger by pings rather than `.autodelete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ pip3 install discord
 
 You will then need an application ID and bot token, which you can obtain on the [Discord Developer Portal](https://discord.com/developers/applications) after creating an application and generating a bot token. Make sure to copy the bot token somewhere, as it is only ever displayed once, and you must reset the token, triggering two-factor authentication, to get another.
 
-In the settings for your new application, go into Settings/Bot, and under Privileged Gateway Intents, enable:
-
-> Message Content Intent
-> Required for your bot to receive message content in most messages.
-
-before saving the settings.
-
 You may then add the bot to the server you wish to use it on by visiting a URL like this in a browser:
 `https://discord.com/api/oauth2/authorize?client_id=APPLICATION_ID_GOES_HERE&permissions=76800&scope=bot`
 where `APPLICATION_ID_GOES_HERE` is the application ID shown for the bot under Settings/General Information.


### PR DESCRIPTION
This change allows Melodelete to stay unaware of the contents of messages it deletes from the userbase of the server, while allowing it to get the contents of messages aimed at it. From <https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ>:

> If your bot or app is not approved for message content, the following fields of the message object in Gateway and API payloads will be empty—either an empty string or empty array, depending on the data type—when you receive a message:
>
> * `content`
> * `embeds`
> * `attachments`
> * `components`
>
> A bot can still **send** these fields. A bot will also **always** be able to get this information from:
>
> * Messages the bot sends
> * Messages the bot receives in DMs
> * Messages in which the bot is mentioned

This enhances privacy, while reducing the size of API responses, thus using less bandwidth and increasing performance while scanning for messages to delete.

After this change, commands are:

* @​bot ping - Check for the bot being up and check the invoking user's permissions
* @​bot clear - Remove the channel this was typed in from the configuration
* @​bot refresh - Scan through messages and delete them one more time
* @​bot config - View the autodelete settings for the channel this was typed in
* @​bot -h<hours> -max<messages> - Set the autodelete settings for the channel this was typed in