### PR TITLE
Ensure that only one main loop (on_ready) ever runs concurrently

### DIFF
--- a/melodelete.py
+++ b/melodelete.py
@@ -117,10 +117,27 @@ async def delete_old_messages():
         else:
             print(f"Channel not found: {channel_id}")
 
+# Since on_ready may be called more than once during a bot session, we need to
+# make sure our main loop is only run once.
+# See <https://discordpy.readthedocs.io/en/stable/api.html#discord.on_ready>
+# This function is not guaranteed to be the first event called. Likewise, this
+# function is *not* guaranteed to only be called once. This library implements
+# reconnection logic and thus will end up calling this event whenever a RESUME
+# request fails.
+main_loop_started = False
+
 @client.event
 async def on_ready():
     print(f"Logged in as {client.user.name}")
     #logging.info(f"Logged in as {client.user.name}")
+
+    # Only start this loop once.
+    global main_loop_started
+    if main_loop_started:
+        return
+
+    main_loop_started = True
+
     while True:
         await count_messages_to_delete()
         print("------")


### PR DESCRIPTION
Per [the discord.py documentation for the `on_ready` function](https://discordpy.readthedocs.io/en/stable/api.html#discord.on_ready), emphasis mine:
> Warning: This function is not guaranteed to be the first event called. **Likewise, this function is not guaranteed to only be called once.** This library implements reconnection logic and thus will end up calling this event whenever a RESUME request fails.

In PR #3, `on_ready` became a long-running function, but since it could be called twice or more, further invocations need to be blocked. Multiple invocations could prevent the bot from working properly due to deadlock on resources or cause shadow bans as they trample over each other's use of the rate limit.