### PR TITLE
Unify and enhance logging

### DIFF
--- a/melodelete.py
+++ b/melodelete.py
@@ -71,13 +71,13 @@ async def on_request_end(session, trace_config_ctx, params):
                 # The time to reset is assumed to apply equally to every
                 # request before this one.
                 rate_limit = float(params.response.headers["X-RateLimit-Reset-After"]) / int(params.response.headers["X-RateLimit-Limit"])
-                logging.info(f"Rate limit is now {rate_limit} seconds")
+                logger.info(f"Rate limit is now {rate_limit} seconds")
         except ValueError:
-            logging.warn(f"Rate-limiting header values malformed (X-RateLimit-Reset-After: {params.response.headers['X-RateLimit-Reset-After']}; X-RateLimit-Limit: {params.response.headers['X-RateLimit-Limit']}; X-RateLimit-Remaining: {params.response.headers['X-RateLimit-Remaining']})")
+            logger.warn(f"Rate-limiting header values malformed (X-RateLimit-Reset-After: {params.response.headers['X-RateLimit-Reset-After']}; X-RateLimit-Limit: {params.response.headers['X-RateLimit-Limit']}; X-RateLimit-Remaining: {params.response.headers['X-RateLimit-Remaining']})")
         except KeyError:
-            logging.warn("No rate-limiting headers received in response to DELETE")
+            logger.warn("No rate-limiting headers received in response to DELETE")
         except ZeroDivisionError:
-            logging.warn("Rate-limiting headers suggest that we cannot make any requests")
+            logger.warn("Rate-limiting headers suggest that we cannot make any requests")
 
 trace_config = aiohttp.TraceConfig()
 trace_config.on_request_end.append(on_request_end)


### PR DESCRIPTION
In this pull request, all logging in Melodelete is now done through a Melodelete module logger.

Also, the default logging from discord.py is suppressed so that Melodelete's `logging.basicConfig` can output both to standard error and to file. Previously, logging would be output twice to standard error, but not twice to file, because discord.py's default logging would output on standard error too.

I have also added the discriminator and ID of the bot on login, and replaced "Channel {channel.name}" with "#{channel.name}" throughout. Every iteration of message scanning and deletion now starts with `-- New scan --`.