### PR TITLE
Remove channels from auto-delete if they are no longer found

### DIFF
--- a/config.py
+++ b/config.py
@@ -114,6 +114,8 @@ class Config:
 
         channels = [channel for channel in channels if channel["id"] != channel_id]
 
+        self.config["channels"] = channels
+
         self.save_config()
 
     def get_rate_limit(self) -> float:


### PR DESCRIPTION
This PR also contains a fix to `Config.clear_channel()` which did not store the new channels back to the configuration dictionary.

This PR depends on #16, because one of the `await` statements added by #16 would conflict with the `try`/`except` added by this one.