### PR TITLE
Restart the bot whenever it gets a transient transport error

### DIFF
--- a/melodelete.py
+++ b/melodelete.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 import asyncio
+import time
 import aiohttp
 import os
 from datetime import datetime, timedelta, timezone
@@ -243,4 +244,14 @@ if __name__ == '__main__':
                         ])
 
     # Run the bot
-    Melodelete().run(log_handler=None)
+    while True:
+        try:
+            Melodelete().run(log_handler=None)
+        # Sometimes a WebSocketError is raised whenever a fragmented control
+        # frame arrives, which may simply be a symptom of packet loss. This,
+        # however, causes run() to return. We need to restart the bot.
+        except aiohttp.http_websocket.WebSocketError as e:
+            logger.exception("Transport error; reconnecting in 60 seconds", e)
+            time.sleep(60)
+        else:  # no WebSocketError has been raised; allow KeyboardInterrupt etc.
+            break


### PR DESCRIPTION
Melodelete can receive a `WebSocketError` while running if it suffers from a network error at either its own end or Discord's end at just the wrong time. On Test Melodelete, I saw the prompt return when that happened, and it has happened 3 times so far. The traceback is always the same: (expand for more)
<details>

```
2024-04-25 23:03:03,519 melodelete      INFO     #More testing (ID: 1226720823654748180) has 0 messages to delete.
Traceback (most recent call last):
  File "/storage/programming/melodelete/melodelete.py", line 244, in <module>
    Melodelete().run(log_handler=None)
  File "/storage/programming/melodelete/melodelete.py", line 43, in run
    super().run(token if token is not None else self.config.get_token(), **kwargs)
  File "/home/nebuleon/.local/lib/python3.10/site-packages/discord/client.py", line 860, in run
    asyncio.run(runner())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/nebuleon/.local/lib/python3.10/site-packages/discord/client.py", line 849, in runner
    await self.start(token, reconnect=reconnect)
  File "/storage/programming/melodelete/melodelete.py", line 46, in start
    await super().start(token if token is not None else self.config.get_token(), **kwargs)
  File "/home/nebuleon/.local/lib/python3.10/site-packages/discord/client.py", line 778, in start
    await self.connect(reconnect=reconnect)
  File "/home/nebuleon/.local/lib/python3.10/site-packages/discord/client.py", line 659, in connect
    await self.ws.poll_event()
  File "/home/nebuleon/.local/lib/python3.10/site-packages/discord/gateway.py", line 626, in poll_event
    raise msg.data
  File "/home/nebuleon/.local/lib/python3.10/site-packages/aiohttp/client_ws.py", line 244, in receive
    msg = await self._reader.read()
[...]
  File "/home/nebuleon/.local/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 486, in parse_frame
    raise WebSocketError(
aiohttp.http_websocket.WebSocketError: Received fragmented control frame
nebuleon@porygon2 /storage/programming/melodelete$
```
</details>

As this is not great for a long-running service, I have fixed that in this commit.