### PR TITLE
Migrate channel configuration to a new, more efficient format

### DIFF
--- a/melodelete.py
+++ b/melodelete.py
@@ -86,17 +86,15 @@ class Melodelete(commands.Bot):
             await asyncio.sleep(max(self.config.get_scan_interval(), 2) * 60)
 
     async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
-        channels = self.config.get_channels()
         channel = self.get_channel(payload.channel_id) or await self.fetch_channel(payload.channel_id)
 
-        if channel and payload.channel_id in [channel["id"] for channel in channels]:
+        if channel and self.config.is_channel_set(payload.channel_id):
             logger.info(f"Message deleted in #{channel.name} (ID: {payload.channel_id})")
 
     async def on_raw_bulk_message_delete(self, payload: discord.RawBulkMessageDeleteEvent) -> None:
-        channels = self.config.get_channels()
         channel = self.get_channel(payload.channel_id) or await self.fetch_channel(payload.channel_id)
 
-        if channel and payload.channel_id in [channel["id"] for channel in channels]:
+        if channel and self.config.is_channel_set(payload.channel_id):
             logger.info(f"{len(payload.message_ids)} messages deleted in #{channel.name} (ID: {payload.channel_id})")
 
     async def get_channel_deletable_messages(self, channel, time_threshold: Optional[int], max_messages: Optional[int]) -> Sequence[discord.Message]:
@@ -205,8 +203,8 @@ class Melodelete(commands.Bot):
 
         # Copy the list from self.config so that we may delete from it with
         # clear_channel if a channel is no longer on the server.
-        for channel_config in list(self.config.get_channels()):
-            channel_id = channel_config["id"]
+        for channel_id in list(self.config.get_channels()):
+            channel_config = self.config.get_channel_config(channel_id)
             time_threshold = channel_config.get("time_threshold", None)
             max_messages = channel_config.get("max_messages", None)
             try:

--- a/melodelete_commands.py
+++ b/melodelete_commands.py
@@ -65,12 +65,11 @@ class AutodeleteCommands(app_commands.Group):
             channel = interaction.channel
 
         if hours is None and messages is None:
-            for channel_config in self.config.get_channels():
-                if channel.id == channel_config["id"]:
-                    time_threshold_hours = f"{channel_config['time_threshold'] // 60} hours" if "time_threshold" in channel_config and channel_config["time_threshold"] is not None else "Not set"
-                    messages = channel_config["max_messages"] if "max_messages" in channel_config and channel_config["max_messages"] is not None else "Not set"
-                    await interaction.response.send_message(f"Current settings for {channel.mention}:\n- Time threshold: {time_threshold_hours}\n- Max messages: {messages}")
-                    break
+            channel_config = self.config.get_channel_config(channel.id)
+            if channel_config is not None:
+                time_threshold_hours = f"{channel_config['time_threshold'] // 60} hours" if "time_threshold" in channel_config and channel_config["time_threshold"] is not None else "Not set"
+                messages = channel_config["max_messages"] if "max_messages" in channel_config and channel_config["max_messages"] is not None else "Not set"
+                await interaction.response.send_message(f"Current settings for {channel.mention}:\n- Time threshold: {time_threshold_hours}\n- Max messages: {messages}")
             else:  # channel not found
                 await interaction.response.send_message(f"{channel.mention} is not configured for auto-delete.")
         else:


### PR DESCRIPTION
Previously, the value of the `channels` entry in the configuration was a list of channels, each element being a dictionary having a channel ID, time_threshold and max_messages. This required **linear time** to determine if a channel was set up for auto-delete or not, or to check what a channel's auto-delete configuration was.

This commit introduces a new format for the value of the `channels` entry, which is a dictionary that maps channel IDs to dictionaries containing time_threshold and max_messages. This way:
* checking whether a channel is set up for auto-delete becomes the **constant-time** operation `Config.is_channel_set()` rather than linear-time;
* getting a single channel's auto-delete settings by ID becomes the **constant-time** operation `Config.get_channel_config()` rather than linear-time;
* getting a list of channels set up for auto-delete becomes the **constant-time** operation `Config.get_channels()` rather than the linear-time `[channel["id"] for channel in channels]`;
* adding and removing channels no longer traverse a whole list to check whether a channel is set up for auto-delete; those become **constant-time** operations rather than linear-time;
* iterating over the list of channels set up for auto-delete stays a linear-time operation.

In particular, checking whether a message deleted on the server belongs to an auto-deleted channel to show "Message deleted in {channel}" in the log becomes constant-time as well.

This also paves the way for a database-backed version of `Config`:
* `Config.is_channel_set()` could map to `SELECT COUNT(*) FROM channels WHERE channel_id = ?`;
* `Config.get_channel_config()` could map to `SELECT * FROM channels WHERE channel_id = ?`;
* `Config.get_channels()` could map to `SELECT channel_id FROM channels`;
* `Config.set_channel()` could map to `INSERT INTO channels (channel_id, time_threshold, max_messages) VALUES (?1, ?2, ?3) ON DUPLICATE KEY UPDATE time_threshold=?2, max_messages=?3`;
* `Config.clear_channel()` could map to `DELETE FROM channels WHERE channel_id = ?`.

On startup, Melodelete reads the list of dictionaries format and converts it internally to the new single-dictionary format. This new format is saved back to storage after the first change to configuration occurs.